### PR TITLE
feat(workflows): adding goReleaser on push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,8 @@
 name: goreleaser
 on:
   push:
-    branches:
-     - master
+    tags:
+      - "*"
 
 jobs:
   goreleaser:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,26 +1,25 @@
-name: test-build
+name: goreleaser
 on:
   push:
     branches:
-      - master
+     - master
+
 jobs:
-  build:
+  goreleaser:
     runs-on: ubuntu-latest
     steps:
-      - name: Install Go
-        uses: actions/setup-go@v1
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v2
         with:
           go-version: 1.15.x
-      - name: Checkout code
-        uses: actions/checkout@v1
-      - name: build
-        run: |
-          export GO111MODULE=on
-          GOOS=windows GOARCH=amd64 go build -o bin/magic-home-windows-amd64.exe
-          GOOS=linux   GOARCH=amd64 go build -o bin/magic-home-linux-amd64
-          GOOS=darwin  GOARCH=amd64 go build -o bin/magic-home-darwin-amd64
-      - name: upload artifacts
-        uses: actions/upload-artifact@master
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
         with:
-          name: binaries
-          path: bin/
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,40 @@
+before:
+  hooks:
+    - go mod download
+
+builds:
+  - env:
+      - CGO_ENABLED=0
+    mod_timestamp: '{{ .CommitTimestamp }}'
+    flags:
+      - -trimpath
+    ldflags:
+      - '-s -w -X main.version={{.Version}} -X main.commit={{.Commit}}'
+    goos:
+      - freebsd
+      - windows
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - '386'
+      - arm
+      - arm64
+    ignore:
+      - goos: darwin
+        goarch: '386'
+    binary: '{{ .ProjectName }}_v{{ .Version }}'
+
+archives:
+  - format: zip
+    name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
+
+checksum:
+  name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
+  algorithm: sha256
+
+release:
+  draft: true
+
+changelog:
+  skip: true


### PR DESCRIPTION
### What's Changed
I added [goReleaser](https://github.com/goreleaser/goreleaser) to run on every push to master


- If you want any aditional configurations, I can add a [.goreleaser.yml](https://github.com/goreleaser/goreleaser/blob/master/.goreleaser.yml)
- I can also change it to only release when you add a new tag with
```yml
 push:
    tags:
      - "*"
```
Closes #9